### PR TITLE
Fixing an XSS attack + removing broken template literals

### DIFF
--- a/public/chatClient.js
+++ b/public/chatClient.js
@@ -28,7 +28,7 @@ function sendMessage() {
   if (!!msg) {
     appendMsg('me', 'me', msg);
     const name = document.querySelector('#my-name').value;
-    socket.send`{"name":"${name}", "msg":"${msg}"}`);
+    socket.send(JSON.stringify({"name":name, "msg":msg}));
     msgEl.value = '';
   }
 }

--- a/public/chatClient.js
+++ b/public/chatClient.js
@@ -28,7 +28,7 @@ function sendMessage() {
   if (!!msg) {
     appendMsg('me', 'me', msg);
     const name = document.querySelector('#my-name').value;
-    socket.send(`{"name":"${name}", "msg":"${msg}"}`);
+    socket.send`{"name":"${name}", "msg":"${msg}"}`);
     msgEl.value = '';
   }
 }
@@ -36,9 +36,16 @@ function sendMessage() {
 // Create one long list of messages
 function appendMsg(cls, from, msg) {
   const chatText = document.querySelector('#chat-text');
-  chatText.innerHTML =
-    `<div><span class="${cls}">${from}</span>: ${msg}</div>` +
-    chatText.innerHTML;
+  const wrapper = document.createElement("div");
+  const fromEl = document.createElement("span");
+  
+  fromEl.classList.add(cls);
+  fromEl.textContent = from;
+  
+  wrapper.appendChild(fromEl);
+  wrapper.append(": "+msg);
+  
+  chatText.prepend(wrapper);
 }
 
 // Send message on enter keystroke


### PR DESCRIPTION
Previously, any message the user sent would be serialized as HTML for any other users. This could let a malicious user send a message that when interacted with, executed some arbitrary JS. (i did this while in class lol) This has been fixed by replacing the template literal that serialized other users' messages with a process of creating new elements and setting their `textContent`.

Additionally, messages could not previously contain quotation marks as they were inserted directly into a string to send to other users, and thus the extra quotation mark would make the JSON invalid. This has been fixed by replacing the template literal with calling JSON.stringify on an object created with the needed properties.